### PR TITLE
chore: add rule for isEditorVariant usage

### DIFF
--- a/lib/rules/no-functional-editor-variant-check.js
+++ b/lib/rules/no-functional-editor-variant-check.js
@@ -1,0 +1,51 @@
+const message = `🚨 Do not use the functional isEditorVariant() after plugin/editor creation;
+  -> use query editor.isEditorVariant(), or in components call hook useEditorVariants() 
+`;
+
+module.exports = {
+  meta: {
+    fixable: "code",
+    type: "problem",
+  },
+  message,
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const isCheckEditorVaraint = (
+          node.callee.name === 'isEditorVariant'
+        )
+
+        if (!isCheckEditorVaraint) {
+          return;
+        }
+
+        const isUsingEditorQuery = (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object &&
+          node.callee.object.name === 'editor'
+        )
+
+        if (isUsingEditorQuery) {
+          return;
+        }
+
+        // traverse scopes upward to check for editor instance 
+        let scope = context.getScope()
+        let isEditorInScope = false
+
+        while (scope && !isEditorInScope) {
+          isEditorInScope = scope.variables.some((variable) => {
+            return variable.name === 'editor'
+          }) 
+          scope = scope.upper
+        }
+
+        if (isEditorInScope) {
+          context.report({ node, message }); 
+        }
+         
+      },
+    };
+  },
+};

--- a/tests/lib/rules/no-functional-editor-variant-check.js
+++ b/tests/lib/rules/no-functional-editor-variant-check.js
@@ -1,0 +1,97 @@
+const rule = require("../../../lib/rules/no-functional-editor-variant-check.js");
+
+const isEditorVariant = () => null
+const EditorVariant = { foo: true }
+
+function validPlugin() {
+  const isFooEditor = isEditorVariant(EditorVariant.foo) 
+  return {
+    queries: {
+      bar(editor) {
+        if (isFooEditor) {
+          return 
+        }
+        return editor.value.startNode
+      }
+    }
+  }
+}
+
+function validPluginWithQuery() {
+  return {
+    queries: {
+      bar(editor) {
+        if (editor.isEditorVariant(EditorVariant.foo)) {
+          return 
+        }
+        return editor.value.startNode
+      }
+    }
+  }
+}
+
+function invalidPlugin() {
+  return {
+    queries: {
+      bar(editor) {
+        if (isEditorVariant(EditorVariant.foo)) {
+          return 
+        }
+        return editor.value.startNode
+      }
+    }
+  }
+}
+
+function invalidPluginWithNestedCommand() {
+  const maybeClearSelection = (editor) => {
+    return () => {
+      if (isEditorVariant(EditorVariant.foo)) {
+        editor.setSelection({})
+      }
+    }
+  }
+  return {
+    queries: {
+      bar(editor) {
+        return editor.value.startNode
+      }
+    },
+    commands: {
+      doSomething: (editor, arg, next) => {
+        next(maybeClearSelection(editor))
+      }
+    }
+  }
+}
+
+// eslint-disable-next-line node/no-unpublished-require
+const { RuleTester } = require("eslint");
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 10 } });
+
+const errors = [
+  {
+    message: rule.message,
+  },
+];
+
+ruleTester.run("no-functional-editor-variant-check", rule, {
+  valid: [
+    {
+      code: validPlugin.toString(),
+    },
+    {
+      code: validPluginWithQuery.toString(),
+    },
+  ],
+  invalid: [
+    {
+      code: invalidPlugin.toString(),
+      errors,
+    },
+    {
+      code: invalidPluginWithNestedCommand.toString(),
+      errors,
+    },
+  ],
+});


### PR DESCRIPTION
This rule enforces the correct use of checking `isEditorVariant` as an _editor instance_ query after plugin/editor creation, and only using the purely functional check during _initial_ construction before you have an editor instance. It should help avoid confusion. 