### PR TITLE
add add_api-ensure-repositories-are-scoped-by-organizationId rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 9,
+    "sourceType": "module"
+  },
+  "env": {
+    "jest": true,
+    "node": true,
+    "jasmine": true
+  },
+  "rules": {
+    "no-debugger": "error"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -6,5 +6,6 @@ module.exports = {
     "no-unchecked-drop-migrations": require("./lib/rules/no-unchecked-drop-migrations"),
     "api-avoid-dangerous-promises": require("./lib/rules/api-avoid-dangerous-promises"),
     "api-ensure-create-slite-context-correctness": require("./lib/rules/api-ensure-create-slite-context-correctness"),
+    "api-ensure-repositories-are-scoped-by-organizationId": require("./lib/rules/api-ensure-repositories-are-scoped-by-organizationId"),
   },
 };

--- a/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
+++ b/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
@@ -1,0 +1,71 @@
+function findProperty(objectExpression, keyName){
+  return objectExpression?.properties?.find(property => {
+    return property.key?.name === keyName
+  })
+}
+
+function isOrganizationIdUsed(objectExpression) {
+  const whereProperty = findProperty(objectExpression, 'where')
+  if(!whereProperty){
+    return false
+  }
+
+  if(whereProperty.value.type === 'ObjectExpression'){
+    const organizationIdWhereProperty = findProperty(whereProperty.value, 'organizationId')
+    if(organizationIdWhereProperty){
+      return true
+    }
+  }
+  
+  const includeProperty = findProperty(objectExpression, 'include')
+  if(!includeProperty){
+    return false
+  }
+  for(const includedModel of includeProperty.value.elements) {
+    const organizationIdIsUsed = isOrganizationIdUsed(includedModel)
+    if(organizationIdIsUsed) {
+      return true
+    }
+  }
+  return false
+}
+
+module.exports = {
+  meta: {
+    fixable: "code",
+    type: "problem",
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callName = node.callee?.property?.name
+        if(!callName){
+          return
+        }
+        if(callName === 'findByPk'){
+          return context.report({
+            node,
+            message:
+              `findByPk should be used with extra care as it opens code to direct object access.
+You should consider using findOne({where: {id, organizationId}}) instead (and add the more context you can like organizationId)`,
+          }); 
+        }
+
+        const sequelizeProtectedCalls = ['findOne', 'findAll']
+        if(sequelizeProtectedCalls.includes(callName)){
+          if(callName.startsWith('find')){
+            const organizationIdIsUsed = isOrganizationIdUsed(node.arguments[0])
+            if(!organizationIdIsUsed){
+              return context.report({
+                node,
+                message:
+                  `${callName} should somehow use organizationId to scope the query to the organization.`,
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
+++ b/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
@@ -31,6 +31,12 @@ function isOrganizationIdUsed(objectExpression) {
 }
 
 module.exports = {
+  errors: {
+    findByPk:
+        `findByPk should be used with extra care as it opens code to direct object access.
+You should consider using findOne({where: {id, organizationId}}) instead (and add the more context you can like organizationId)`,
+    findOne: `findOne should somehow use organizationId to scope the query to the organization.`
+  },
   meta: {
     fixable: "code",
     type: "problem",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-slite",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "description": "A set of rules used for code linting at @Slite",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-slite",
-  "version": "0.0.7",
+  "version": "0.0.5",
   "description": "A set of rules used for code linting at @Slite",
   "main": "index.js",
   "license": "MIT",

--- a/tests/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
+++ b/tests/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
@@ -4,16 +4,6 @@ const ruleTester = new RuleTester({
   parserOptions: { ecmaVersion: 10, sourceType: "module" },
 });
 
-const errorFindByPk = {
-  message:
-      `findByPk should be used with extra care as it opens code to direct object access.
-You should consider using findOne({where: {id, organizationId}}) instead (and add the more context you can like organizationId)`,
-}
-
-const errorFindOne = {
-  message: `findOne should somehow use organizationId to scope the query to the organization.`,
-}
-
 ruleTester.run("ensure-repository-has-context", rule, {
   valid: [
     { 
@@ -44,13 +34,13 @@ ruleTester.run("ensure-repository-has-context", rule, {
     { code: `
         PGNote.findByPk(noteId, { transaction })
       `,
-      errors: [errorFindByPk]
+      errors: [rule.errors.findByPk]
     },
     { 
       code: `
         PGNote.findOne({ transaction, where: {noteId} })
       `,
-      errors: [errorFindOne]
+      errors: [rule.errors.findOne]
     },
     {
       code: `
@@ -60,7 +50,7 @@ ruleTester.run("ensure-repository-has-context", rule, {
           include: [{ model: PGNote, required: true }],
         })
       `,
-      errors: [errorFindOne]
+      errors: [rule.errors.findOne]
     }
   ],
 });

--- a/tests/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
+++ b/tests/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
@@ -1,0 +1,66 @@
+const rule = require("../../../lib/rules/api-ensure-repositories-are-scoped-by-organizationId");
+const { RuleTester } = require("eslint");
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 10, sourceType: "module" },
+});
+
+const errorFindByPk = {
+  message:
+      `findByPk should be used with extra care as it opens code to direct object access.
+You should consider using findOne({where: {id, organizationId}}) instead (and add the more context you can like organizationId)`,
+}
+
+const errorFindOne = {
+  message: `findOne should somehow use organizationId to scope the query to the organization.`,
+}
+
+ruleTester.run("ensure-repository-has-context", rule, {
+  valid: [
+    { 
+      code: `
+        PGNote.findOne({ transaction, where: {noteId, organizationId} })
+      `
+    },
+    { 
+      code: `
+        PGNoteDisplayOption.findOne({
+          where: { noteId },
+          transaction: services.transaction,
+          include: [{ model: PGNote, required: true, where: { organizationId }, attributes: [] }],
+        })
+      `
+    },
+    { 
+      code: `
+        const where = {noteId: 'noteId'};
+        PGNote.findOne({
+          where: {...where, organizationId: 'organizationId'},
+          transaction: services.transaction,
+        });
+      `
+    },
+  ],
+  invalid: [
+    { code: `
+        PGNote.findByPk(noteId, { transaction })
+      `,
+      errors: [errorFindByPk]
+    },
+    { 
+      code: `
+        PGNote.findOne({ transaction, where: {noteId} })
+      `,
+      errors: [errorFindOne]
+    },
+    {
+      code: `
+        PGNoteDisplayOption.findOne({
+          where: { noteId },
+          transaction: services.transaction,
+          include: [{ model: PGNote, required: true }],
+        })
+      `,
+      errors: [errorFindOne]
+    }
+  ],
+});


### PR DESCRIPTION
I'll activate this as warning for now to try to prevent new repository function to be created without organizationId scope.

Otherwise I'll never terminate this job :p 