### PR TITLE
fix(api): fix eslint rule to support nested includes and improve error message

### DIFF
--- a/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
+++ b/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
@@ -6,11 +6,7 @@ function findProperty(objectExpression, keyName){
 
 function isOrganizationIdUsed(objectExpression) {
   const whereProperty = findProperty(objectExpression, 'where')
-  if(!whereProperty){
-    return false
-  }
-
-  if(whereProperty.value.type === 'ObjectExpression'){
+  if(whereProperty && whereProperty.value.type === 'ObjectExpression'){
     const organizationIdWhereProperty = findProperty(whereProperty.value, 'organizationId')
     if(organizationIdWhereProperty){
       return true
@@ -35,7 +31,42 @@ module.exports = {
     findByPk:
         `findByPk should be used with extra care as it opens code to direct object access.
 You should consider using findOne({where: {id, organizationId}}) instead (and add the more context you can like organizationId)`,
-    findOne: `findOne should somehow use organizationId to scope the query to the organization.`
+    findOneAll: `findOne/findAll should somehow use organizationId to scope the query to the organization.
+You can do SQL JOIN by using sequelize include option and even nested include.
+By specifying "attributes:[]" in the include, the JOIN would only be used for filtering without returning the object.
+
+ℹ️ Example:
+
+// PGDiscussionReply is a child of PGThread which is a child of PGNote which contains organizationId
+
+PGDiscussionReply.findOne({
+  where: {
+    id: replyId,
+  },
+  transaction,
+  include: [
+    {
+      model: PGThread,
+      required: true,
+      include: [
+        {
+          model: PGNote,
+          where: { organizationId },
+          attributes: [],
+          required: true,
+        },
+      ],
+    },
+  ],
+})
+
+// This would add the following INNER JOIN to the SQL query:
+
+// INNER JOIN "threads" AS "thread"
+// ON "PGDiscussionReply"."threadId" = "thread"."id"
+// INNER JOIN "notes" AS "thread->note"
+// ON "thread"."noteId" = "thread->note"."id" AND "thread->note"."organizationId" = 'organizationId'
+`
   },
   meta: {
     fixable: "code",
@@ -52,9 +83,7 @@ You should consider using findOne({where: {id, organizationId}}) instead (and ad
         if(callName === 'findByPk'){
           return context.report({
             node,
-            message:
-              `findByPk should be used with extra care as it opens code to direct object access.
-You should consider using findOne({where: {id, organizationId}}) instead (and add the more context you can like organizationId)`,
+            message: module.exports.errors.findByPk,
           }); 
         }
 
@@ -65,8 +94,7 @@ You should consider using findOne({where: {id, organizationId}}) instead (and ad
             if(!organizationIdIsUsed){
               return context.report({
                 node,
-                message:
-                  `${callName} should somehow use organizationId to scope the query to the organization.`,
+                message: module.exports.errors.findOneAll,
               });
             }
           }

--- a/tests/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
+++ b/tests/lib/rules/api-ensure-repositories-are-scoped-by-organizationId.js
@@ -29,6 +29,47 @@ ruleTester.run("ensure-repository-has-context", rule, {
         });
       `
     },
+    { code:`
+      PGDiscussionReply.findOne({
+        where: {
+          id: replyId,
+        },
+        transaction,
+        include: [
+          {
+            model: PGThread,
+            required: true,
+            include: [
+              {
+                model: PGNote,
+                where: { organizationId },
+                attributes: [],
+                required: true,
+              },
+            ],
+          },
+        ],
+      })
+    `},
+    { code:`
+      PGDiscussionReply.findAll({
+        transaction,
+        include: [
+          {
+            model: PGThread,
+            required: true,
+            include: [
+              {
+                model: PGNote,
+                where: { organizationId },
+                attributes: [],
+                required: true,
+              },
+            ],
+          },
+        ],
+      })
+    `}
   ],
   invalid: [
     { code: `
@@ -40,7 +81,7 @@ ruleTester.run("ensure-repository-has-context", rule, {
       code: `
         PGNote.findOne({ transaction, where: {noteId} })
       `,
-      errors: [rule.errors.findOne]
+      errors: [rule.errors.findOneAll]
     },
     {
       code: `
@@ -50,7 +91,7 @@ ruleTester.run("ensure-repository-has-context", rule, {
           include: [{ model: PGNote, required: true }],
         })
       `,
-      errors: [rule.errors.findOne]
+      errors: [rule.errors.findOneAll]
     }
   ],
 });


### PR DESCRIPTION
Nested includes wasn't considered if no `where` was in the parent include.

where is not mandatory to have an include so this is the fix.

I also added more documentation on how to do nested includes in the error message.