### PR TITLE
chore: export editor variant rule, bump version

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
     "api-avoid-dangerous-promises": require("./lib/rules/api-avoid-dangerous-promises"),
     "api-ensure-create-slite-context-correctness": require("./lib/rules/api-ensure-create-slite-context-correctness"),
     "api-ensure-repositories-are-scoped-by-organizationId": require("./lib/rules/api-ensure-repositories-are-scoped-by-organizationId"),
+    "no-functional-editor-variant-check": require("./lib/rules/no-functional-editor-variant-check"),
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-slite",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A set of rules used for code linting at @Slite",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Quick chore; just never exported this rule and am about to enable it on the editor