### PR TITLE
chore: add rule for unnecessary usecallback

### DIFF
--- a/lib/rules/no-memoization-for-dom-element-callbacks.js
+++ b/lib/rules/no-memoization-for-dom-element-callbacks.js
@@ -1,0 +1,89 @@
+const message = `⚠️ There is no benefit to memoizing callbacks to DOM elements
+  https://github.com/facebook/react/issues/17055
+`
+
+function isReactMemoizedCallback(node) {
+  if (!node.init || !node.init.callee) {
+    return false
+  }
+  const { callee } = node.init
+  return (
+    callee.name === 'useCallback' ||
+    (callee.type === 'MemberExpression' &&
+      callee.object.name === 'React' &&
+      callee.property.name === 'useCallback')
+  )
+}
+
+function jsxAttributeIsDOMNode(node) {
+  const tag = node.parent.name.name
+  return (tag && typeof tag === 'string' && tag[0] !== tag[0].toUpperCase())
+}
+
+module.exports = {
+  meta: {
+    fixable: "code",
+    type: "problem",
+  },
+  message,
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (!jsxAttributeIsDOMNode(node)) { 
+          // This is a Component, not a DOM node
+          return
+        }
+
+        if (!node.value || !node.value.expression) {
+          return
+        }
+
+        const name = node.value.expression.name
+
+        // traverse scopes upward to check for variable declaration
+        let scope = context.getScope()
+        let variableDefinition = null
+
+        while (scope && !variableDefinition) {
+          variableDefinition = scope.variables.find((variable) => 
+            variable.name === name &&
+            variable.defs &&
+            variable.defs[0] &&
+            variable.defs[0].node 
+          )
+          scope = scope.upper
+        }
+
+        if (!variableDefinition) {
+          return
+        }
+
+        if (!isReactMemoizedCallback(variableDefinition.defs[0].node)) {
+          return
+        }
+
+        // check if this variabe is used in multiple places, and another is valid
+        const hasOtherValidUse = variableDefinition.references.some((reference) => {
+          if (
+            reference.identifier.parent.type === 'JSXExpressionContainer' &&
+            reference.identifier.parent.parent.type === 'JSXAttribute'
+          ) {
+            if (!jsxAttributeIsDOMNode(reference.identifier.parent.parent)) {
+              return true
+            }
+          } 
+        })
+
+        if (hasOtherValidUse) {
+          return
+        }
+
+        context.report({
+          node,
+          message
+        })
+      },
+    }
+  },
+}

--- a/lib/rules/no-memoization-for-dom-element-callbacks.js
+++ b/lib/rules/no-memoization-for-dom-element-callbacks.js
@@ -39,6 +39,11 @@ module.exports = {
           return
         }
 
+        if (node.name.name === 'ref') {
+          // memoizing a ref function makes sense
+          return
+        }
+
         const name = node.value.expression.name
 
         // traverse scopes upward to check for variable declaration

--- a/lib/rules/no-memoization-for-dom-element-callbacks.js
+++ b/lib/rules/no-memoization-for-dom-element-callbacks.js
@@ -75,9 +75,13 @@ module.exports = {
             reference.identifier.parent.parent.type === 'JSXAttribute'
           ) {
             if (!jsxAttributeIsDOMNode(reference.identifier.parent.parent)) {
+              // supplied to a custom component
               return true
             }
-          } 
+          } else if (reference.identifier.parent.type !== 'VariableDeclarator') {
+            // some other invocation in the component, outside jsx
+            return true 
+          }
         })
 
         if (hasOtherValidUse) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "roots": [
           "."
         ],
-        "testRegex": "/tests/lib/rules/.+\\.js$",
+        "testRegex": "/tests/lib/rules/.+\\.jsx?$",
         "testEnvironment": "node"
       }
     ]

--- a/tests/lib/rules/no-memoization-for-dom-element-callbacks.jsx
+++ b/tests/lib/rules/no-memoization-for-dom-element-callbacks.jsx
@@ -3,7 +3,7 @@ const rule = require("../../../lib/rules/no-memoization-for-dom-element-callback
 const ValidComponentWithoutMemo = `
   const MyComponent = () => {
     const handleClick = (event) => {
-      event.preventDefault
+      event.preventDefault()
     }
     return (
       <div
@@ -17,7 +17,7 @@ const ValidComponentWithInlineFunction = `
   const MyComponent = () => {
     return (
       <div
-        onClick={(event) => event.preventDefault}
+        onClick={(event) => event.preventDefault()}
       />
     )
   }
@@ -26,7 +26,7 @@ const ValidComponentWithInlineFunction = `
 const ValidComponentWithMixedUses = `
   const MyComponent = () => {
     const handleClick = React.useCallback((event) => {
-      event.preventDefault
+      event.preventDefault()
     }, [])
     return (
       <div>
@@ -34,6 +34,40 @@ const ValidComponentWithMixedUses = `
           onClick={handleClick}
         />
         <div onClick={handleClick} />
+      </div>
+    )
+  }
+`
+
+const ValidComponentWithDependentUses = `
+  const MyComponent = ({ foo }) => {
+    const handleClick = React.useCallback(() => {
+      foo()
+    }, [ foo ])
+
+    // this uses the above as a dependency
+    useEffect(() => handleClick(), [ handleClick ])
+
+    return (
+      <div>
+        <div onClick={handleClick} />
+      </div>
+    )
+  }
+`
+
+const ValidComponentWithOtherDependentUses = `
+  const MyComponent = ({ foo }) => {
+    const handleClick = React.useCallback(() => {
+      foo()
+    }, [ foo ])
+
+    // supplied to another hook
+    const attributes = useMyCustomHook({ foo, click: handleClick })
+
+    return (
+      <div>
+        <div onClick={handleClick} { ...attributes } />
       </div>
     )
   }
@@ -55,7 +89,7 @@ const MyComponent = () => {
 const InvalidComponentWithMemo = `
   const MyComponent = () => {
     const handleClick = React.useCallback((event) => {
-      event.preventDefault
+      event.preventDefault()
     }, [])
     return (
       <div
@@ -68,7 +102,7 @@ const InvalidComponentWithMemo = `
 const InvalidComponentWithMemoAlt = `
   const MyComponent = () => {
     const handleClick = useCallback((event) => {
-      event.preventDefault
+      event.preventDefault()
     }, [])
     return (
       <div
@@ -98,6 +132,12 @@ ruleTester.run("no-memoization-for-dom-element-callbacks", rule, {
     },
     {
       code: ValidComponentWithMixedUses,
+    },
+    {
+      code: ValidComponentWithDependentUses
+    },
+    {
+      code: ValidComponentWithOtherDependentUses,
     },
     {
       code: ValidComponentWithRef,

--- a/tests/lib/rules/no-memoization-for-dom-element-callbacks.jsx
+++ b/tests/lib/rules/no-memoization-for-dom-element-callbacks.jsx
@@ -1,0 +1,100 @@
+const rule = require("../../../lib/rules/no-memoization-for-dom-element-callbacks.js")
+
+const ValidComponentWithoutMemo = `
+  const MyComponent = () => {
+    const handleClick = (event) => {
+      event.preventDefault
+    }
+    return (
+      <div
+        onClick={handleClick}
+      />
+    )
+  }
+`
+
+const ValidComponentWithInlineFunction = `
+  const MyComponent = () => {
+    return (
+      <div
+        onClick={(event) => event.preventDefault}
+      />
+    )
+  }
+`
+
+const ValidComponentWithMixedUses = `
+  const MyComponent = () => {
+    const handleClick = React.useCallback((event) => {
+      event.preventDefault
+    }, [])
+    return (
+      <div>
+        <CustomComponent
+          onClick={handleClick}
+        />
+        <div onClick={handleClick} />
+      </div>
+    )
+  }
+`
+
+const InvalidComponentWithMemo = `
+  const MyComponent = () => {
+    const handleClick = React.useCallback((event) => {
+      event.preventDefault
+    }, [])
+    return (
+      <div
+        onClick={handleClick}
+      />
+    )
+  }
+`
+
+const InvalidComponentWithMemoAlt = `
+  const MyComponent = () => {
+    const handleClick = useCallback((event) => {
+      event.preventDefault
+    }, [])
+    return (
+      <div
+        onClick={handleClick}
+      />
+    )
+  }
+`
+
+// eslint-disable-next-line node/no-unpublished-require
+const { RuleTester } = require("eslint")
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 10, ecmaFeatures: { jsx: true } } })
+
+const errors = [
+  {
+    message: rule.message,
+  },
+]
+
+ruleTester.run("no-memoization-for-dom-element-callbacks", rule, {
+  valid: [
+    {
+      code: ValidComponentWithoutMemo,
+    },
+    {
+      code: ValidComponentWithInlineFunction,
+    },
+    {
+      code: ValidComponentWithMixedUses,
+    }
+  ],
+  invalid: [
+    {
+      code: InvalidComponentWithMemo,
+      errors,
+    },
+    {
+      code: InvalidComponentWithMemoAlt,
+      errors,
+    }
+  ],
+})

--- a/tests/lib/rules/no-memoization-for-dom-element-callbacks.jsx
+++ b/tests/lib/rules/no-memoization-for-dom-element-callbacks.jsx
@@ -39,6 +39,19 @@ const ValidComponentWithMixedUses = `
   }
 `
 
+const ValidComponentWithRef = `
+const MyComponent = () => {
+  const refCallback = useCallback((element) => {
+    element.focus()
+  }, [])
+  return (
+    <div
+      ref={refCallback}
+    />
+  )
+}
+`
+
 const InvalidComponentWithMemo = `
   const MyComponent = () => {
     const handleClick = React.useCallback((event) => {
@@ -85,6 +98,9 @@ ruleTester.run("no-memoization-for-dom-element-callbacks", rule, {
     },
     {
       code: ValidComponentWithMixedUses,
+    },
+    {
+      code: ValidComponentWithRef,
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-memoization-for-dom-element-callbacks.jsx
+++ b/tests/lib/rules/no-memoization-for-dom-element-callbacks.jsx
@@ -74,16 +74,16 @@ const ValidComponentWithOtherDependentUses = `
 `
 
 const ValidComponentWithRef = `
-const MyComponent = () => {
-  const refCallback = useCallback((element) => {
-    element.focus()
-  }, [])
-  return (
-    <div
-      ref={refCallback}
-    />
-  )
-}
+  const MyComponent = () => {
+    const refCallback = useCallback((element) => {
+      element.focus()
+    }, [])
+    return (
+      <div
+        ref={refCallback}
+      />
+    )
+  }
 `
 
 const InvalidComponentWithMemo = `


### PR DESCRIPTION
Somewhat related to [this conversation](https://slite.slite.com/app/docs/9SxJeDeOetLPHP?commentId=WXO0dAqQ8tTnUf&source=notifications), create a new rule that flags unnecessary uses of `useCallback`, where we are pointlessly memoizing functions that are only passed into normal DOM nodes rather than custom components. 

See the valid / invalid test cases for an overview of cases. This can help us clean up our code, particularly in many editor components, where I've enabled it locally and can see many bad uses correctly flagged. 