### PR TITLE
feat(api): detect missing transaction in PG sequelize calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,6 @@ module.exports = {
     "no-functional-editor-variant-check": require("./lib/rules/no-functional-editor-variant-check"),
     "no-memoization-for-dom-element-callbacks": require("./lib/rules/no-memoization-for-dom-element-callbacks"),
     "api-unique-debugging-id": require("./lib/rules/api-unique-debugging-id"),
+    "api-ensure-transaction-is-passed-to-sequelize": require("./lib/rules/api-ensure-transaction-is-passed-to-sequelize"),
   },
 };

--- a/lib/rules/api-ensure-transaction-is-passed-to-sequelize.js
+++ b/lib/rules/api-ensure-transaction-is-passed-to-sequelize.js
@@ -1,0 +1,86 @@
+function findProperty(objectExpression, keyName) {
+  return objectExpression?.properties?.find((property) => {
+    return property.key?.name === keyName
+  })
+}
+
+function isTransactionUsed(objectExpression) {
+  const transactionProperty = findProperty(objectExpression, 'transaction')
+  if (transactionProperty) {
+    return true
+  }
+
+  return false
+}
+
+module.exports = {
+  errors: {
+    missingTransaction: `You should always pass the services.transaction as transaction to sequelize in case the current function is wrapped in a transaction.`,
+  },
+  meta: {
+    fixable: 'code',
+    type: 'problem',
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callName = node.callee?.property?.name
+        const objectName = node.callee?.object?.name
+        if (
+          !callName ||
+          (!objectName &&
+            callName !== 'query' &&
+            node.callee?.object?.property?.name !== 'sequelize') ||
+          (objectName && !objectName.startsWith('PG'))
+        ) {
+          return
+        }
+
+        const sequelizeProtectedCallsWithOneArgument = [
+          'findOne',
+          'findAll',
+          'count',
+          'findAndCountAll',
+          'findOrBuild',
+          'findOrCreate',
+          'truncate',
+          'destroy',
+          'restore',
+        ]
+        if (sequelizeProtectedCallsWithOneArgument.includes(callName)) {
+          const transactionIsUsed = isTransactionUsed(node.arguments[0])
+          if (!transactionIsUsed) {
+            return context.report({
+              node,
+              message: module.exports.errors.missingTransaction,
+            })
+          }
+        }
+
+        const sequelizeProtectedCallsWithTwoArguments = [
+          'query',
+          'create',
+          'findByPk',
+          'update',
+          'upsert',
+          'max',
+          'min',
+          'sum',
+          'bulkCreate',
+          'increment',
+          'decrement',
+        ]
+        if (sequelizeProtectedCallsWithTwoArguments.includes(callName)) {
+          const transactionIsUsed = isTransactionUsed(node.arguments[1])
+          if (!transactionIsUsed) {
+            return context.report({
+              node,
+              message: module.exports.errors.missingTransaction,
+            })
+          }
+        }
+      },
+    }
+  },
+}

--- a/tests/lib/rules/api-ensure-transaction-is-passed-to-sequelize.js
+++ b/tests/lib/rules/api-ensure-transaction-is-passed-to-sequelize.js
@@ -1,0 +1,133 @@
+const rule = require("../../../lib/rules/api-ensure-transaction-is-passed-to-sequelize");
+const { RuleTester } = require("eslint");
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 10, sourceType: "module" },
+});
+
+ruleTester.run("ensure-repository-has-context", rule, {
+  valid: [
+    {
+      code: `response.locals.services.metrics.increment('http_request')`
+    },
+    { 
+      code: `
+        PGNote.findOne({ transaction, where: {noteId, organizationId} })
+      `
+    },
+    { 
+      code: `
+        services.db.sequelize.query('SELECT * FROM organizations', { transaction })
+      `
+    },
+    { 
+      code: `
+        PGNoteDisplayOption.create({ noteId }, {
+          transaction: services.transaction,
+        })
+      `
+    },
+    { 
+      code: `
+        const where = {noteId: 'noteId'};
+        PGNote.upsert({
+            organizationId: 'organizationId'
+          },
+          {
+            transaction: services.transaction,
+          }
+        );
+      `
+    },
+    { code:`
+      PGDiscussionReply.update({id: testId}, {
+        where: {
+          id: replyId,
+        },
+        transaction,
+      })
+    `
+    },
+    { code:`
+      PGDiscussionReply.findAll({
+        transaction,
+        include: [
+          {
+            model: PGThread,
+            required: true,
+            include: [
+              {
+                model: PGNote,
+                where: { organizationId },
+                attributes: [],
+                required: true,
+              },
+            ],
+          },
+        ],
+      })
+    `
+    }
+  ],
+  invalid: [
+    { 
+      code: `
+        PGNote.findOne({ where: {noteId, organizationId} })
+      `,
+      errors: [rule.errors.missingTransaction]
+    },
+    {
+      code: `
+        services.db.sequelize.query('SELECT * FROM organizations')
+      `,
+      errors: [rule.errors.missingTransaction]
+    },
+    { 
+      code: `
+        PGNoteDisplayOption.create({ noteId })
+      `,
+      errors: [rule.errors.missingTransaction]
+    },
+    { 
+      code: `
+        const where = {noteId: 'noteId'};
+        PGNote.upsert({
+          organizationId: 'organizationId'
+          }, 
+        );
+      `,
+      errors: [rule.errors.missingTransaction]
+    },
+    { code:`
+      PGDiscussionReply.update(
+        { id: 'testId' },
+        {
+          where: {
+            id: 'replyId',
+          },
+        }
+      )
+    `,
+      errors: [rule.errors.missingTransaction]
+    },
+    { code:`
+      PGDiscussionReply.findAll({
+        include: [
+          {
+            model: PGThread,
+            required: true,
+            include: [
+              {
+                model: PGNote,
+                where: { organizationId },
+                attributes: [],
+                required: true,
+              },
+            ],
+          },
+        ],
+      })
+    `,
+    errors: [rule.errors.missingTransaction]
+    }
+  ],
+});


### PR DESCRIPTION
It only detects when PGModel is used so we may still miss some spot but I think it's a good starting point.

detected 25 missing transaction on the api codebase.