### PR TITLE
Add security checks on dangerous usage

### DIFF
--- a/lib/rules/api-avoid-empty-permissions-asserters.js
+++ b/lib/rules/api-avoid-empty-permissions-asserters.js
@@ -1,0 +1,77 @@
+const errorMessage = `🚨 Are you sure you don't need any permissions asserters ?
+
+Most of the USER or PUBLIC_SHARING contexts represent actions on some objects (note, discussion, channel...) done by a specific user.
+
+First thing we should think about is: does the user is allowed to execute this action ?
+
+Based on the parameter names of your context you should get an idea of what permission you should check.
+
+Ex: \`commentId\`, is the user allowed to act on this \`commentId\` ?
+
+Fortunately we already have plenty of generic asserters in \`src/helpers/permissions.ts\`, don't hesitate to have a look.
+
+In our example you can use \`assertCanActOnCommentId\` which will retrieve the thread of the comment 
+and then check for the read permission on the note of the thread.
+
+Of course you can chain multiple generic asserters together to cover every parameters.
+
+Ex:
+
+\`\`\`
+async function UserMovesNotesToChannelCallback(
+  services: Services,
+  {
+    noteIdList,
+    channelId,
+  }: {
+    noteIdList: PGNote['id'][]
+    channelId: PGChannel['id']
+  }
+) 
+
+[...]
+
+export const UserMovesNotesToChannel = createSliteContext(
+  {
+    type: SliteContextType.USER,
+    wrapInTransaction: true,
+    permissionsAsserters: [
+      assertCanWriteChannelId,
+      assertCanManageNoteIdList,
+    ]
+  }
+)
+\`\`\`
+
+It could also be global organization permissions like \`assertCanManageOrganization\` or \`assertCanUpdateOrganization\`...
+
+And of course there is some cases where there is no need to check for any permissions.
+
+⚠️ If you specify an empty array, please add a comment to explain why as security team may have a second look.
+`;
+
+module.exports = {
+  meta: {
+    fixable: "code",
+    type: "problem",
+  },
+
+  errorMessage,
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if(node.callee.name !== 'createSliteContext'){
+          return
+        }
+        const emptyPermissionAssertersArgument = node.arguments[0].properties.find((property) => property.key.name === 'permissionsAsserters' && property.value.elements.length === 0)
+        if(emptyPermissionAssertersArgument){
+          context.report({
+            node: node.callee,
+            message: errorMessage,
+          });
+        }     
+      },
+    };
+  },
+};

--- a/lib/rules/api-avoid-empty-permissions-asserters.js
+++ b/lib/rules/api-avoid-empty-permissions-asserters.js
@@ -2,7 +2,7 @@ const errorMessage = `🚨 Are you sure you don't need any permissions asserters
 
 Most of the USER or PUBLIC_SHARING contexts represent actions on some objects (note, discussion, channel...) done by a specific user.
 
-First thing we should think about is: does the user is allowed to execute this action ?
+First thing we should think about is: Is the user allowed to execute this action ?
 
 Based on the parameter names of your context you should get an idea of what permission you should check.
 

--- a/lib/rules/api-avoid-unsafe-function.js
+++ b/lib/rules/api-avoid-unsafe-function.js
@@ -2,7 +2,7 @@ const errorMessage = `🚨 Are you sure you need the unsafe version of this func
 
 \`unsafe\` repository functions usage should be restricted to internal usage (via Forest), scheduled global tasks or very specific public related contexts
 
-Indeed, these functions are not scoped with the concerned \`organizationId\` so it could leads to vulnerabilities in
+Indeed, these functions are not scoped with the concerned \`organizationId\` so it could lead to vulnerabilities in
 our horizontal segmentation (an attacker could access data across organizations).
 
 Always try to find a way to retrieve \`organizationId\` for which you are doing the current action.

--- a/lib/rules/api-avoid-unsafe-function.js
+++ b/lib/rules/api-avoid-unsafe-function.js
@@ -1,0 +1,45 @@
+const errorMessage = `🚨 Are you sure you need the unsafe version of this function ?
+
+\`unsafe\` repository functions usage should be restricted to internal usage (via Forest), scheduled global tasks or very specific public related contexts
+
+Indeed, these functions are not scoped with the concerned \`organizationId\` so it could leads to vulnerabilities in
+our horizontal segmentation (an attacker could access data across organizations).
+
+Always try to find a way to retrieve \`organizationId\` for which you are doing the current action.
+
+From a \`USER\` context, you can use:
+
+\`\`\`
+const {
+  userId,
+  organizationId,
+} = services.permissions.getAuthenticatedUserAndOrganizationId()
+\`\`\`
+
+
+From a \`SYSTEM\` context, you could surely find \`organizationId\` attached to some already resolved PG Objects.
+
+⚠️ If you still need to use it, please add a comment to explain why as security team may have a second look.
+`;
+
+module.exports = {
+  meta: {
+    fixable: "code",
+    type: "problem",
+  },
+
+  errorMessage,
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if(node.callee.name.startsWith('unsafe')){
+          context.report({
+            node: node.callee,
+            message: errorMessage,
+          });
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/api-avoid-empty-permissions-asserters.js
+++ b/tests/lib/rules/api-avoid-empty-permissions-asserters.js
@@ -1,0 +1,41 @@
+const rule = require("../../../lib/rules/api-avoid-empty-permissions-asserters");
+
+const { RuleTester } = require("eslint");
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 10 } });
+
+const errors = [
+  {
+    message: rule.errorMessage,
+  },
+];
+
+ruleTester.run("api-avoid-empty-permissions-asserters", rule, {
+  valid: [
+    {
+      code: `
+      const UserAcknowledgesNoteActivity = createSliteContext(
+        { type: SliteContextType.USER, permissionsAsserters: [assertCanReadNoteId] },
+        UserAcknowledgesNoteActivityCallback
+      )      
+      `,
+
+      code: `
+      const SystemAcknowledgesNoteActivity = createSliteContext(
+        { type: SliteContextType.SYSTEM },
+        SystemAcknowledgesNoteActivityCallback
+      )      
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      const UserAcknowledgesNoteActivity = createSliteContext(
+        { type: SliteContextType.USER, permissionsAsserters: [] },
+        UserAcknowledgesNoteActivityCallback
+      )      
+      `,
+      errors,
+    },
+  ],
+});

--- a/tests/lib/rules/api-avoid-unsafe-function.js
+++ b/tests/lib/rules/api-avoid-unsafe-function.js
@@ -1,0 +1,32 @@
+const rule = require("../../../lib/rules/api-avoid-unsafe-function");
+
+const { RuleTester } = require("eslint");
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 10 } });
+
+const errors = [
+  {
+    message: rule.errorMessage,
+  },
+];
+
+ruleTester.run("api-avoid-unsafe-function", rule, {
+  valid: [
+    {
+      code: `
+      async function context() {
+        const note = await findNoteById(services, { noteId })
+      }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      async function context() {
+        const note = await unsafeFindNoteById(services, { noteId })
+      }
+      `,
+      errors,
+    },
+  ],
+});


### PR DESCRIPTION
Discussed with @Shahor, those are also checked by the CI to ping slack channel #dev-security to have a second security look.

But it's better to have an eslint rule first to explain why it's dangerous.