### PR TITLE
Add no assignment from asserters rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,5 +14,6 @@ module.exports = {
     "api-avoid-empty-permissions-asserters": require("./lib/rules/api-avoid-empty-permissions-asserters"),
     "api-avoid-unsafe-function": require("./lib/rules/api-avoid-unsafe-function"),
     "api-enforce-create-slite-context-usage": require("./lib/rules/api-enforce-create-slite-context-usage"),
+    "api-no-assignment-from-asserters": require("./lib/rules/api-no-assignment-from-asserters"),
   },
 };

--- a/lib/rules/api-no-assignment-from-asserters.js
+++ b/lib/rules/api-no-assignment-from-asserters.js
@@ -1,0 +1,35 @@
+const errors = {
+  noAssignmentFromAsserters: `Asserters are supposed to throw or do nothing but they are not supposed to return anything.
+  Doing so could hide a future problem as we saw with the [Wrong privilege assignment on guest link invitation](https://slite.slite.com/app/docs/W3IxlN8RKSMurD).
+  Either rename the function to be more explicit about what it does or fetch the thing you want in another function.
+  `,
+};
+
+const ASSIGNMENT_AST = ['VariableDeclarator', 'AssignmentExpression']
+
+module.exports = {
+  meta: {
+    fixable: "code",
+    type: "problem",
+  },
+
+  errors,
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callName = node.callee?.name
+        if(!callName || !callName.startsWith('assert')){
+          return
+        }
+
+        if(ASSIGNMENT_AST.includes(node.parent?.type) || (node.parent?.type === 'AwaitExpression' && ASSIGNMENT_AST.includes(node.parent.parent?.type))) {
+          context.report({
+            node,
+            message: module.exports.errors.noAssignmentFromAsserters
+          });
+        }
+    }
+    };
+  },
+};

--- a/tests/lib/rules/api-no-assignment-from-asserters.js
+++ b/tests/lib/rules/api-no-assignment-from-asserters.js
@@ -1,0 +1,88 @@
+const rule = require("../../../lib/rules/api-no-assignment-from-asserters");
+
+const { RuleTester } = require("eslint");
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 10, sourceType: "module" },
+});
+
+ruleTester.run("api-no-assignment-from-asserters", rule, {
+  valid: [
+    {
+      filename: "api/src/helpers/authentication.ts",
+      code: `
+      async function a(){
+        await assertCanAutoJoin({
+          services,
+          loginData,
+          organization,
+        })
+      }
+    `,
+    },
+    {
+      filename: "api/src/helpers/authentication.ts",
+      code: `
+      assertIsGuest({
+        user,
+      })
+    `,
+    },
+  ],
+  invalid: [
+    {
+      filename: "api/src/helpers/authentication.ts",
+      code: `
+      async function a(){
+        const { joinToken, autoJoinMethod } = await assertCanAutoJoin({
+          services,
+          loginData,
+          organization,
+        })
+      }
+        `,
+      errors: [{ message: rule.errors.noAssignmentFromAsserters }],
+    },
+    {
+      filename: "api/src/helpers/authentication.ts",
+      code: `
+      const guest = assertIsGuest({
+        user
+      })
+        `,
+      errors: [{ message: rule.errors.noAssignmentFromAsserters }],
+    },
+    {
+      filename: "api/src/helpers/authentication.ts",
+      code: `
+      let guest = null
+      guest = assertIsGuest({
+        user
+      })
+        `,
+      errors: [{ message: rule.errors.noAssignmentFromAsserters }],
+    },
+    {
+      filename: "api/src/helpers/authentication.ts",
+      code: `
+        async function a(){
+          const guest = await assertIsGuest({
+            user
+          })
+        }
+        `,
+      errors: [{ message: rule.errors.noAssignmentFromAsserters }],
+    },
+    {
+      filename: "api/src/helpers/authentication.ts",
+      code: `
+      async function a(){
+        const {guest} = await assertIsGuest({
+          user
+        })
+      }
+      
+        `,
+      errors: [{ message: rule.errors.noAssignmentFromAsserters }],
+    },
+  ],
+});


### PR DESCRIPTION
Following the security bug "Wrong privilege assignment on guest link invitation" https://slite.slite.com/app/docs/W3IxlN8RKSMurD

We could detect the bad practice of using asserter to return value.